### PR TITLE
Add iOS bridging layer

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1857,6 +1857,16 @@ if (DARWIN)
   list(APPEND viewer_SOURCE_FILES ${viewer_RESOURCE_FILES})
 endif (DARWIN)
 
+if (IOS)
+  LIST(APPEND viewer_SOURCE_FILES llappviewerosx-ios-objc.mm)
+  LIST(APPEND viewer_SOURCE_FILES llappviewerosx-ios-objc.h)
+  set_source_files_properties(
+    llappviewerosx-ios-objc.mm
+    PROPERTIES
+    SKIP_PRECOMPILE_HEADERS TRUE
+  )
+endif (IOS)
+
 if (LINUX)
     LIST(APPEND viewer_SOURCE_FILES llappviewerlinux.cpp)
     set_source_files_properties(

--- a/indra/newview/ViewerIOS-Bridging.h
+++ b/indra/newview/ViewerIOS-Bridging.h
@@ -1,0 +1,8 @@
+#ifndef VIEWER_IOS_BRIDGING_H
+#define VIEWER_IOS_BRIDGING_H
+
+#include "llappviewerosx-ios-objc.h"
+#include "llappviewer.h"
+#include "llscenemonitor.h"
+
+#endif // VIEWER_IOS_BRIDGING_H

--- a/indra/newview/llappviewerosx-ios-objc.h
+++ b/indra/newview/llappviewerosx-ios-objc.h
@@ -1,0 +1,19 @@
+#ifndef LL_LLAPPVIEWERIOS_OBJC_H
+#define LL_LLAPPVIEWERIOS_OBJC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ios_construct_viewer(void);
+bool ios_init_viewer(void);
+bool ios_pump_frame(void);
+void ios_handle_url(const char* url_utf8);
+void ios_quit(void);
+void ios_cleanup_viewer(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // LL_LLAPPVIEWERIOS_OBJC_H

--- a/indra/newview/llappviewerosx-ios-objc.mm
+++ b/indra/newview/llappviewerosx-ios-objc.mm
@@ -1,0 +1,32 @@
+#include "llappviewerosx-ios-objc.h"
+#include "llappviewermacosx-for-objc.h"
+
+void ios_construct_viewer(void)
+{
+    constructViewer();
+}
+
+bool ios_init_viewer(void)
+{
+    return initViewer();
+}
+
+bool ios_pump_frame(void)
+{
+    return pumpMainLoop();
+}
+
+void ios_handle_url(const char* url_utf8)
+{
+    handleUrl(url_utf8);
+}
+
+void ios_quit(void)
+{
+    handleQuit();
+}
+
+void ios_cleanup_viewer(void)
+{
+    cleanupViewer();
+}


### PR DESCRIPTION
## Summary
- add Objective-C++ wrappers so Swift can drive viewer functionality on iOS
- provide a bridging header with common viewer types
- compile bridging source when the IOS build flag is set

## Testing
- `python3 -m unittest discover -v indra/test` *(fails: ImportError: test_llmanifest)*

------
https://chatgpt.com/codex/tasks/task_e_685f971d7b08833291e1bac2acb7e511