### PR TITLE
Add iOS CI workflow and minimal UI test

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,25 @@
+name: iOS Build
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-ios:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: brew install cmake
+      - name: Build viewer library for iOS
+        run: |
+          mkdir build-ios
+          cd build-ios
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-iOS.cmake ../indra/newview
+          cmake --build . --config Release
+      - name: Build Swift package for simulator
+        run: |
+          xcodebuild -scheme FinalviewerApp -destination 'platform=iOS Simulator,name=iPhone 15' build
+      - name: Run UI tests
+        run: |
+          xcodebuild -scheme FinalviewerApp -destination 'platform=iOS Simulator,name=iPhone 15' test

--- a/doc/ios_app.md
+++ b/doc/ios_app.md
@@ -1,5 +1,7 @@
 # Finalviewer iOS App
 
+[![iOS Build](https://github.com/finalviewer/finalviewer/actions/workflows/ios.yml/badge.svg)](https://github.com/finalviewer/finalviewer/actions/workflows/ios.yml)
+
 This folder contains a minimal Swift package that can be opened in Xcode to run the viewer core on iOS.
 
 ## Prerequisites
@@ -21,3 +23,13 @@ This folder contains a minimal Swift package that can be opened in Xcode to run 
 - Modify `Package.swift` if additional resource bundles are needed.
 
 The SwiftUI interface provides login, chat and HUD layers while `WorldView` uses SceneKit with gesture recognizers for camera control. The `ViewerBridge` layer exposes functions from the C++ core.
+
+## Running tests
+
+Run the UI tests on a simulator with:
+
+```bash
+xcodebuild -scheme FinalviewerApp -destination 'platform=iOS Simulator,name=iPhone 15' test
+```
+
+This matches the command executed by the continuous integration workflow.

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -28,6 +28,11 @@ let package = Package(
             name: "FinalviewerApp",
             dependencies: ["ViewerBridge"],
             path: "Sources/FinalviewerApp"
+        ),
+        .testTarget(
+            name: "FinalviewerAppUITests",
+            dependencies: ["FinalviewerApp"],
+            path: "Tests/FinalviewerAppUITests"
         )
     ]
 )

--- a/ios/Tests/FinalviewerAppUITests/FinalviewerAppUITests.swift
+++ b/ios/Tests/FinalviewerAppUITests/FinalviewerAppUITests.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class FinalviewerAppUITests: XCTestCase {
+    func testLoginScreenAppears() {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.textFields["Username"].exists)
+        XCTAssertTrue(app.secureTextFields["Password"].exists)
+        XCTAssertTrue(app.buttons["Login"].exists)
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build viewer library for iOS and run simulator tests
- extend Swift Package to include UI test target
- add a minimal UI test verifying the login screen
- document CI badge and test instructions for the iOS app

## Testing
- `pre-commit run --files ios/Package.swift ios/Tests/FinalviewerAppUITests/FinalviewerAppUITests.swift doc/ios_app.md .github/workflows/ios.yml` *(fails: command not found)*
- `xcodebuild -scheme FinalviewerApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa45a98ac8332a720e2e96e87aec1